### PR TITLE
Rename project to FeedMyLedger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,17 +30,17 @@ jobs:
         run: cargo build --release
       - name: Strip
         if: runner.os != 'Windows'
-        run: strip target/release/rusty-ledger
+        run: strip target/release/feed-my-ledger
       - name: Package
         id: package
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p dist
-          name=rusty-ledger-${{ github.ref_name }}-${{ matrix.target }}
+          name=feed-my-ledger-${{ github.ref_name }}-${{ matrix.target }}
           bin=target/release
           if [[ "$RUNNER_OS" == 'Windows' ]]; then
-            cp "$bin/rusty-ledger.exe" "$name.exe"
+            cp "$bin/feed-my-ledger.exe" "$name.exe"
             7z a "dist/$name.zip" "$name.exe"
             if command -v sha256sum >/dev/null; then
               sha256sum "dist/$name.zip" > "dist/$name.zip.sha256"
@@ -50,7 +50,7 @@ jobs:
             echo "archive=dist/$name.zip" >> "$GITHUB_OUTPUT"
             echo "checksum=dist/$name.zip.sha256" >> "$GITHUB_OUTPUT"
           else
-            cp "$bin/rusty-ledger" "$name"
+            cp "$bin/feed-my-ledger" "$name"
             tar czf "dist/$name.tar.gz" "$name"
             if command -v sha256sum >/dev/null; then
               sha256sum "dist/$name.tar.gz" > "dist/$name.tar.gz.sha256"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENT Guidelines for rusty-ledger
+# AGENT Guidelines for feed-my-ledger
 
 This file outlines best practices for working with this Rust project.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to rusty-ledger
+# Contributing to feed-my-ledger
 
-Thank you for considering contributing to **rusty-ledger**! Your contributions help improve the project and are greatly appreciated.
+Thank you for considering contributing to **feed-my-ledger**! Your contributions help improve the project and are greatly appreciated.
 
 ## Table of Contents
 
@@ -65,8 +65,8 @@ To set up the development environment:
 2. Clone the repository:
 
    ```bash
-   git clone https://github.com/yourusername/rusty-ledger.git
-   cd rusty-ledger
+   git clone https://github.com/yourusername/feed-my-ledger.git
+   cd feed-my-ledger
    ```
 
 3. Build the project:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "feed-my-ledger"
+version = "2.0.0"
+dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
+ "chrono",
+ "clap",
+ "cron",
+ "csv",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "indicatif",
+ "iso_currency",
+ "rand",
+ "rhai",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
+ "uuid",
+ "wiremock",
+ "yup-oauth2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,31 +1508,6 @@ name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
-
-[[package]]
-name = "rusty-ledger"
-version = "2.0.0"
-dependencies = [
- "aes-gcm",
- "base64 0.22.1",
- "chrono",
- "clap",
- "cron",
- "csv",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "indicatif",
- "iso_currency",
- "rand",
- "rhai",
- "serde",
- "serde_json",
- "tokio",
- "toml",
- "uuid",
- "wiremock",
- "yup-oauth2",
-]
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rusty-ledger"
+name = "feed-my-ledger"
 version = "2.0.0"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Rusty Ledger (rusty-ledger) 
+# FeedMyLedger (feed-my-ledger)
 
-[![Release](https://github.com/Softwareologists/rusty-ledger/actions/workflows/release.yml/badge.svg)](https://github.com/Softwareologists/rusty-ledger/actions/workflows/release.yml)
-[![CI](https://github.com/Softwareologists/rusty-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/Softwareologists/rusty-ledger/actions/workflows/ci.yml)
+[![Release](https://github.com/Softwareologists/feed-my-ledger/actions/workflows/release.yml/badge.svg)](https://github.com/Softwareologists/feed-my-ledger/actions/workflows/release.yml)
+[![CI](https://github.com/Softwareologists/feed-my-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/Softwareologists/feed-my-ledger/actions/workflows/ci.yml)
 
 Rust-based library that enables applications to interact with cloud-based spreadsheet services (e.g., Google Sheets) as immutable, append-only databases. It ensures that once data is committed, it cannot be edited or deleted. Adjustments are made by appending new records, akin to double-entry bookkeeping.
 
-![rusty-ledger](https://github.com/user-attachments/assets/6c630732-3bc5-43ac-bcb7-ade199cefcc2)
+![feed-my-ledger](https://github.com/user-attachments/assets/6c630732-3bc5-43ac-bcb7-ade199cefcc2)
 
 # 📦 Features
 - Immutable Data Entries: Once data is committed, it becomes read-only.
@@ -27,12 +27,12 @@ Rust-based library that enables applications to interact with cloud-based spread
 Add the following to your Cargo.toml:
 ```toml
 [dependencies]
-rusty-ledger = "2.0.0"
+feed-my-ledger = "2.0.0"
 ```
 
 ## Usage
 ```rust
-use rusty_ledger::core::{Ledger, Record};
+use feed_my_ledger::core::{Ledger, Record};
 
 fn main() {
     let mut ledger = Ledger::default();
@@ -58,7 +58,7 @@ optionally specify the worksheet name when creating the adapter; otherwise, it
 defaults to `Ledger`:
 
 ```rust,no_run
-use rusty_ledger::cloud_adapters::GoogleSheets4Adapter;
+use feed_my_ledger::cloud_adapters::GoogleSheets4Adapter;
 use yup_oauth2::{self, InstalledFlowAuthenticator, InstalledFlowReturnMethod};
 
 async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -151,7 +151,7 @@ $ cargo run --bin ledger -- download --url "https://bank.example.com/statement.o
 ```
 
 # 🛠️ Configuration
-Rusty Ledger looks for a `config.toml` file in the same directory as the
+FeedMyLedger looks for a `config.toml` file in the same directory as the
 binary. This file stores your OAuth credentials and the spreadsheet ID used by
 the CLI. When using `--local-dir`, only the sheet ID is persisted and no OAuth
 credentials are required.
@@ -209,7 +209,7 @@ credentials are required.
 
 ### Excel 365 Setup
 
-To connect Rusty Ledger to Microsoft Excel 365 you must register an application
+To connect FeedMyLedger to Microsoft Excel 365 you must register an application
 in Azure and provide workbook credentials.
 
 1. Open the [Azure Portal](https://portal.azure.com/) and create a new

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-This directory contains detailed documentation for the Rusty Ledger project. The following guides are available:
+This directory contains detailed documentation for the FeedMyLedger project. The following guides are available:
 
 - [Module Architecture](architecture.md)
 - [Data Model](data_model.md)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 remote_theme: pages-themes/minimal@v0.2.0
 plugins:
 - jekyll-remote-theme
-title: Rusty Ledger
+title: FeedMyLedger
 description: Immutable cloud sheets backed append only ledger
 show_downloads: true
 logo: https://github.com/user-attachments/assets/6c630732-3bc5-43ac-bcb7-ade199cefcc2

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -3,7 +3,7 @@
 The easiest way to use the library is to work with the `Ledger` type directly:
 
 ```rust
-use rusty_ledger::core::{Ledger, Record};
+use feed_my_ledger::core::{Ledger, Record};
 
 let mut ledger = Ledger::default();
 let record = Record::new(
@@ -60,8 +60,8 @@ When integrating with a cloud service, construct an adapter that implements
 `CloudSpreadsheetService` and pass it to `SharedLedger` for multi-user access.
 
 ```rust
-use rusty_ledger::cloud_adapters::GoogleSheetsAdapter;
-use rusty_ledger::core::{Permission, SharedLedger};
+use feed_my_ledger::cloud_adapters::GoogleSheetsAdapter;
+use feed_my_ledger::core::{Permission, SharedLedger};
 
 let adapter = GoogleSheetsAdapter::new();
 let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
@@ -76,7 +76,7 @@ Use the parsers in the `import` module to convert existing statements into `Reco
 Each parser returns a vector of records ready for insertion:
 
 ```rust
-use rusty_ledger::import::{csv, ofx, qif};
+use feed_my_ledger::import::{csv, ofx, qif};
 use std::path::Path;
 
 let records = csv::parse(Path::new("transactions.csv"))?;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Module Architecture
 
-Rusty Ledger is organized into two main modules:
+FeedMyLedger is organized into two main modules:
 
 - **core** – Provides the immutable ledger logic and record structures. It defines the `Record`, `Ledger`, and sharing primitives that control access and apply adjustments.
 - **cloud_adapters** – Contains implementations for interacting with remote spreadsheet services. Adapters implement the `CloudSpreadsheetService` trait and can be wrapped with utilities like batching and retry logic.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -5,7 +5,7 @@ Authentication is provided through the `AuthManager` type in
 OAuth2 flows and a `TokenStore` for persisting tokens.
 
 ```rust,no_run
-use rusty_ledger::cloud_adapters::auth::{AuthManager, MemoryTokenStore, OAuth2Token, AuthProvider};
+use feed_my_ledger::cloud_adapters::auth::{AuthManager, MemoryTokenStore, OAuth2Token, AuthProvider};
 
 struct MyProvider;
 impl AuthProvider for MyProvider {
@@ -26,7 +26,7 @@ via the CLI. The helper `initial_oauth_login` persists the obtained tokens so
 future requests are authenticated automatically.
 
 ```rust,no_run
-use rusty_ledger::cloud_adapters::auth::initial_oauth_login;
+use feed_my_ledger::cloud_adapters::auth::initial_oauth_login;
 
 // Runs the interactive OAuth flow and saves tokens to `tokens.json`.
 tokio::runtime::Runtime::new().unwrap().block_on(async {

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,12 +21,12 @@ title: Overview
 Add the following to your Cargo.toml:
 ```toml
 [dependencies]
-rusty-ledger = "2.0.0"
+feed-my-ledger = "2.0.0"
 ```
 
 ### Usage
 ```rust
-use rusty_ledger::core::{Ledger, Record};
+use feed_my_ledger::core::{Ledger, Record};
 
 fn main() {
     let mut ledger = Ledger::default();
@@ -52,7 +52,7 @@ optionally specify the worksheet name when creating the adapter; otherwise, it
 defaults to `Ledger`:
 
 ```rust,no_run
-use rusty_ledger::cloud_adapters::GoogleSheets4Adapter;
+use feed_my_ledger::cloud_adapters::GoogleSheets4Adapter;
 use yup_oauth2::{self, InstalledFlowAuthenticator, InstalledFlowReturnMethod};
 
 async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -75,7 +75,7 @@ To integrate with Microsoft Excel 365 instead, use the `Excel365Adapter` which
 talks to the Microsoft Graph API:
 
 ```rust,no_run
-use rusty_ledger::cloud_adapters::Excel365Adapter;
+use feed_my_ledger::cloud_adapters::Excel365Adapter;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `auth` must provide OAuth tokens scoped for Microsoft Graph
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 If you prefer to avoid cloud services entirely, `FileAdapter` stores rows in local CSV files:
 
 ```rust,no_run
-use rusty_ledger::cloud_adapters::FileAdapter;
+use feed_my_ledger::cloud_adapters::FileAdapter;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut service = FileAdapter::new("./ledger_data");
@@ -183,7 +183,7 @@ $ cargo run --bin ledger -- download --url "https://bank.example.com/statement.o
 ```
 
 ## 🛠️ Configuration
-Rusty Ledger looks for a `config.toml` file in the same directory as the
+FeedMyLedger looks for a `config.toml` file in the same directory as the
 binary. This file stores your OAuth credentials and the spreadsheet ID used by
 the CLI. When running with `--local-dir`, only the sheet ID is saved and no
 OAuth configuration is needed.
@@ -251,7 +251,7 @@ Azure and a workbook stored in OneDrive or SharePoint.
 3. In **Certificates & secrets** create a client secret and note its value. From
    the **Overview** page also record the **Application (client) ID** and
    **Directory (tenant) ID**.
-4. Create or open the workbook you want Rusty Ledger to use and copy its ID from
+4. Create or open the workbook you want FeedMyLedger to use and copy its ID from
    the share link (or obtain it via the Graph Explorer).
 5. Add the following section to `config.toml`:
    ```toml

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -1,6 +1,6 @@
 # Scripting Examples
 
-Rusty Ledger integrates the [Rhai](https://rhai.rs) scripting language. Use the
+FeedMyLedger integrates the [Rhai](https://rhai.rs) scripting language. Use the
 `run-script` command to execute a script against the current ledger. The script
 receives an array named `records` where each entry is a map containing the
 ledger fields.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Rusty Ledger
+//! FeedMyLedger
 //!
 //! This crate provides an append-only immutable database that can interact with
 //! cloud-based spreadsheet services.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,13 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use clap::{Args, Parser, Subcommand};
-use rusty_ledger::cloud_adapters::{
+use feed_my_ledger::cloud_adapters::{
     CloudSpreadsheetService, FileAdapter, google_sheets4::GoogleSheets4Adapter,
 };
-use rusty_ledger::core::{
+use feed_my_ledger::core::{
     Account, Budget, BudgetBook, Ledger, Period, Posting, PriceDatabase, Query, Record,
 };
-use rusty_ledger::import;
+use feed_my_ledger::import;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -420,7 +420,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         load_config(&config_path).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
 
     if matches!(cli.command, Commands::Login) {
-        rt.block_on(rusty_ledger::cloud_adapters::auth::initial_oauth_login(
+        rt.block_on(feed_my_ledger::cloud_adapters::auth::initial_oauth_login(
             &cfg.google_sheets.credentials_path,
             "tokens.json",
         ))?;
@@ -742,7 +742,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             let script = std::fs::read_to_string(file)?;
-            let result = rusty_ledger::script::run_script(&script, &ledger)?;
+            let result = feed_my_ledger::script::run_script(&script, &ledger)?;
             println!("{}", result);
         }
         Commands::Switch { .. } | Commands::Login => unreachable!(),

--- a/tests/access_control_tests.rs
+++ b/tests/access_control_tests.rs
@@ -1,5 +1,5 @@
-use rusty_ledger::cloud_adapters::GoogleSheetsAdapter;
-use rusty_ledger::core::{AccessError, Permission, Record, SharedLedger};
+use feed_my_ledger::cloud_adapters::GoogleSheetsAdapter;
+use feed_my_ledger::core::{AccessError, Permission, Record, SharedLedger};
 
 #[test]
 fn reader_cannot_write() {

--- a/tests/budget_tests.rs
+++ b/tests/budget_tests.rs
@@ -1,5 +1,5 @@
 use chrono::{TimeZone, Utc};
-use rusty_ledger::core::{Budget, BudgetBook, Ledger, Period, PriceDatabase, Record};
+use feed_my_ledger::core::{Budget, BudgetBook, Ledger, Period, PriceDatabase, Record};
 
 #[test]
 fn monthly_budget_diff() {

--- a/tests/cloud_adapter_tests.rs
+++ b/tests/cloud_adapter_tests.rs
@@ -1,6 +1,6 @@
-use rusty_ledger::cloud_adapters::FileAdapter;
-use rusty_ledger::cloud_adapters::google_sheets4::TokenProvider;
-use rusty_ledger::cloud_adapters::{
+use feed_my_ledger::cloud_adapters::FileAdapter;
+use feed_my_ledger::cloud_adapters::google_sheets4::TokenProvider;
+use feed_my_ledger::cloud_adapters::{
     CloudSpreadsheetService, Excel365Adapter, GoogleSheets4Adapter, GoogleSheetsAdapter,
     SpreadsheetError,
 };

--- a/tests/file_token_store_tests.rs
+++ b/tests/file_token_store_tests.rs
@@ -1,5 +1,5 @@
 use chrono::{Duration, Utc};
-use rusty_ledger::cloud_adapters::auth::{FileTokenStore, OAuth2Token, TokenStore};
+use feed_my_ledger::cloud_adapters::auth::{FileTokenStore, OAuth2Token, TokenStore};
 use uuid::Uuid;
 
 #[test]

--- a/tests/google_sheet_name_tests.rs
+++ b/tests/google_sheet_name_tests.rs
@@ -1,5 +1,5 @@
-use rusty_ledger::cloud_adapters::google_sheets4::TokenProvider;
-use rusty_ledger::cloud_adapters::{
+use feed_my_ledger::cloud_adapters::google_sheets4::TokenProvider;
+use feed_my_ledger::cloud_adapters::{
     CloudSpreadsheetService, GoogleSheets4Adapter, SpreadsheetError,
 };
 

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -1,4 +1,4 @@
-use rusty_ledger::import::{csv, json, ledger, ofx, qif};
+use feed_my_ledger::import::{csv, json, ledger, ofx, qif};
 use std::fs::write;
 
 fn write_temp(name: &str, content: &str) -> std::path::PathBuf {

--- a/tests/initial_login_tests.rs
+++ b/tests/initial_login_tests.rs
@@ -1,4 +1,4 @@
-use rusty_ledger::cloud_adapters::auth::initial_oauth_login;
+use feed_my_ledger::cloud_adapters::auth::initial_oauth_login;
 
 #[tokio::test]
 async fn initial_login_fails_with_missing_credentials() {

--- a/tests/ledger_tests.rs
+++ b/tests/ledger_tests.rs
@@ -1,5 +1,5 @@
 use chrono::{NaiveDate, TimeZone, Utc};
-use rusty_ledger::core::{
+use feed_my_ledger::core::{
     Account, Ledger, LedgerError, Posting, PriceDatabase, Record, RecordError,
 };
 use uuid::Uuid;

--- a/tests/oauth_tests.rs
+++ b/tests/oauth_tests.rs
@@ -1,5 +1,5 @@
 use chrono::{Duration, Utc};
-use rusty_ledger::cloud_adapters::auth::{
+use feed_my_ledger::cloud_adapters::auth::{
     AuthError, AuthManager, AuthProvider, MemoryTokenStore, OAuth2Token, TokenStore,
 };
 

--- a/tests/performance_tests.rs
+++ b/tests/performance_tests.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use rusty_ledger::cloud_adapters::{
+use feed_my_ledger::cloud_adapters::{
     CloudSpreadsheetService, GoogleSheetsAdapter,
     buffered::{BatchingCacheService, EvictionPolicy},
 };
@@ -26,7 +26,7 @@ impl CloudSpreadsheetService for CountingAdapter {
     fn create_sheet(
         &mut self,
         title: &str,
-    ) -> Result<String, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<String, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         self.inner.create_sheet(title)
     }
 
@@ -34,7 +34,7 @@ impl CloudSpreadsheetService for CountingAdapter {
         &mut self,
         sheet_id: &str,
         values: Vec<String>,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         *self.append_calls.borrow_mut() += 1;
         self.inner.append_row(sheet_id, values)
     }
@@ -43,7 +43,7 @@ impl CloudSpreadsheetService for CountingAdapter {
         &self,
         sheet_id: &str,
         index: usize,
-    ) -> Result<Vec<String>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<Vec<String>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         *self.read_calls.borrow_mut() += 1;
         self.inner.read_row(sheet_id, index)
     }
@@ -51,7 +51,7 @@ impl CloudSpreadsheetService for CountingAdapter {
     fn list_rows(
         &self,
         sheet_id: &str,
-    ) -> Result<Vec<Vec<String>>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<Vec<Vec<String>>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         self.inner.list_rows(sheet_id)
     }
 
@@ -59,7 +59,7 @@ impl CloudSpreadsheetService for CountingAdapter {
         &self,
         sheet_id: &str,
         email: &str,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         self.inner.share_sheet(sheet_id, email)
     }
 
@@ -67,7 +67,7 @@ impl CloudSpreadsheetService for CountingAdapter {
         &mut self,
         sheet_id: &str,
         rows: Vec<Vec<String>>,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         *self.append_calls.borrow_mut() += rows.len();
         self.inner.append_rows(sheet_id, rows)
     }

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -1,5 +1,5 @@
 use chrono::{TimeZone, Utc};
-use rusty_ledger::core::{Ledger, Query, Record};
+use feed_my_ledger::core::{Ledger, Query, Record};
 use std::str::FromStr;
 
 #[test]

--- a/tests/reconcile_tests.rs
+++ b/tests/reconcile_tests.rs
@@ -1,5 +1,5 @@
-use rusty_ledger::cloud_adapters::GoogleSheetsAdapter;
-use rusty_ledger::core::{Permission, Record, SharedLedger};
+use feed_my_ledger::cloud_adapters::GoogleSheetsAdapter;
+use feed_my_ledger::core::{Permission, Record, SharedLedger};
 
 #[test]
 fn cleared_status_persists() {

--- a/tests/retry_tests.rs
+++ b/tests/retry_tests.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 
-use rusty_ledger::cloud_adapters::{CloudSpreadsheetService, RetryingService, SpreadsheetError};
+use feed_my_ledger::cloud_adapters::{CloudSpreadsheetService, RetryingService, SpreadsheetError};
 
 struct FlakyAdapter {
     fail_times: usize,

--- a/tests/script_tests.rs
+++ b/tests/script_tests.rs
@@ -1,5 +1,5 @@
-use rusty_ledger::core::{Ledger, Record};
-use rusty_ledger::script::run_script;
+use feed_my_ledger::core::{Ledger, Record};
+use feed_my_ledger::script::run_script;
 
 #[test]
 fn totals_cash_debits() {

--- a/tests/shared_ledger_service_tests.rs
+++ b/tests/shared_ledger_service_tests.rs
@@ -1,8 +1,8 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use rusty_ledger::cloud_adapters::{CloudSpreadsheetService, GoogleSheetsAdapter};
-use rusty_ledger::core::{AccessError, Permission, Record, SharedLedger};
+use feed_my_ledger::cloud_adapters::{CloudSpreadsheetService, GoogleSheetsAdapter};
+use feed_my_ledger::core::{AccessError, Permission, Record, SharedLedger};
 
 struct CountingAdapter {
     inner: GoogleSheetsAdapter,
@@ -22,7 +22,7 @@ impl CloudSpreadsheetService for CountingAdapter {
     fn create_sheet(
         &mut self,
         title: &str,
-    ) -> Result<String, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<String, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         self.inner.create_sheet(title)
     }
 
@@ -30,7 +30,7 @@ impl CloudSpreadsheetService for CountingAdapter {
         &mut self,
         sheet_id: &str,
         values: Vec<String>,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         *self.append_calls.borrow_mut() += 1;
         self.inner.append_row(sheet_id, values)
     }
@@ -39,14 +39,14 @@ impl CloudSpreadsheetService for CountingAdapter {
         &self,
         sheet_id: &str,
         index: usize,
-    ) -> Result<Vec<String>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<Vec<String>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         self.inner.read_row(sheet_id, index)
     }
 
     fn list_rows(
         &self,
         sheet_id: &str,
-    ) -> Result<Vec<Vec<String>>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<Vec<Vec<String>>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         self.inner.list_rows(sheet_id)
     }
 
@@ -54,7 +54,7 @@ impl CloudSpreadsheetService for CountingAdapter {
         &self,
         sheet_id: &str,
         email: &str,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         self.inner.share_sheet(sheet_id, email)
     }
 
@@ -62,7 +62,7 @@ impl CloudSpreadsheetService for CountingAdapter {
         &mut self,
         sheet_id: &str,
         rows: Vec<Vec<String>>,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         *self.append_calls.borrow_mut() += rows.len();
         self.inner.append_rows(sheet_id, rows)
     }
@@ -98,7 +98,7 @@ impl CloudSpreadsheetService for FailingShare {
     fn create_sheet(
         &mut self,
         _title: &str,
-    ) -> Result<String, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<String, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         Ok("sheet1".into())
     }
 
@@ -106,7 +106,7 @@ impl CloudSpreadsheetService for FailingShare {
         &mut self,
         _sheet_id: &str,
         _values: Vec<String>,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 
@@ -114,14 +114,14 @@ impl CloudSpreadsheetService for FailingShare {
         &self,
         _sheet_id: &str,
         _index: usize,
-    ) -> Result<Vec<String>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<Vec<String>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 
     fn list_rows(
         &self,
         _sheet_id: &str,
-    ) -> Result<Vec<Vec<String>>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<Vec<Vec<String>>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 
@@ -129,8 +129,8 @@ impl CloudSpreadsheetService for FailingShare {
         &self,
         _sheet_id: &str,
         _email: &str,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
-        Err(rusty_ledger::cloud_adapters::SpreadsheetError::ShareFailed)
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
+        Err(feed_my_ledger::cloud_adapters::SpreadsheetError::ShareFailed)
     }
 }
 
@@ -151,8 +151,8 @@ impl CloudSpreadsheetService for FailingCreate {
     fn create_sheet(
         &mut self,
         _title: &str,
-    ) -> Result<String, rusty_ledger::cloud_adapters::SpreadsheetError> {
-        Err(rusty_ledger::cloud_adapters::SpreadsheetError::Permanent(
+    ) -> Result<String, feed_my_ledger::cloud_adapters::SpreadsheetError> {
+        Err(feed_my_ledger::cloud_adapters::SpreadsheetError::Permanent(
             "boom".into(),
         ))
     }
@@ -161,7 +161,7 @@ impl CloudSpreadsheetService for FailingCreate {
         &mut self,
         _sheet_id: &str,
         _values: Vec<String>,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 
@@ -169,14 +169,14 @@ impl CloudSpreadsheetService for FailingCreate {
         &self,
         _sheet_id: &str,
         _index: usize,
-    ) -> Result<Vec<String>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<Vec<String>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 
     fn list_rows(
         &self,
         _sheet_id: &str,
-    ) -> Result<Vec<Vec<String>>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<Vec<Vec<String>>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 
@@ -184,7 +184,7 @@ impl CloudSpreadsheetService for FailingCreate {
         &self,
         _sheet_id: &str,
         _email: &str,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 }
@@ -199,7 +199,7 @@ fn new_propagates_spreadsheet_error() {
     };
     assert_eq!(
         err,
-        rusty_ledger::cloud_adapters::SpreadsheetError::Permanent("boom".into())
+        feed_my_ledger::cloud_adapters::SpreadsheetError::Permanent("boom".into())
     );
 }
 
@@ -233,7 +233,7 @@ impl CloudSpreadsheetService for FailingList {
     fn create_sheet(
         &mut self,
         _title: &str,
-    ) -> Result<String, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<String, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         Ok("sheet1".into())
     }
 
@@ -241,7 +241,7 @@ impl CloudSpreadsheetService for FailingList {
         &mut self,
         _sheet_id: &str,
         _values: Vec<String>,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 
@@ -249,22 +249,22 @@ impl CloudSpreadsheetService for FailingList {
         &self,
         _sheet_id: &str,
         _index: usize,
-    ) -> Result<Vec<String>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<Vec<String>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 
     fn list_rows(
         &self,
         _sheet_id: &str,
-    ) -> Result<Vec<Vec<String>>, rusty_ledger::cloud_adapters::SpreadsheetError> {
-        Err(rusty_ledger::cloud_adapters::SpreadsheetError::SheetNotFound)
+    ) -> Result<Vec<Vec<String>>, feed_my_ledger::cloud_adapters::SpreadsheetError> {
+        Err(feed_my_ledger::cloud_adapters::SpreadsheetError::SheetNotFound)
     }
 
     fn share_sheet(
         &self,
         _sheet_id: &str,
         _email: &str,
-    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+    ) -> Result<(), feed_my_ledger::cloud_adapters::SpreadsheetError> {
         unimplemented!()
     }
 }
@@ -276,6 +276,6 @@ fn from_sheet_propagates_errors() {
     let err = res.err().unwrap();
     assert_eq!(
         err,
-        rusty_ledger::cloud_adapters::SpreadsheetError::SheetNotFound
+        feed_my_ledger::cloud_adapters::SpreadsheetError::SheetNotFound
     );
 }

--- a/tests/thread_safety_tests.rs
+++ b/tests/thread_safety_tests.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 use std::thread;
 
-use rusty_ledger::cloud_adapters::GoogleSheetsAdapter;
-use rusty_ledger::core::{Permission, Record, SharedLedger};
+use feed_my_ledger::cloud_adapters::GoogleSheetsAdapter;
+use feed_my_ledger::core::{Permission, Record, SharedLedger};
 
 #[test]
 fn concurrent_commits() {


### PR DESCRIPTION
## Summary
- rename project references from `rusty-ledger` to `FeedMyLedger`
- update documentation and workflow configs
- switch crate name to `feed-my-ledger`

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_b_68660f811298832a9551f6de4dea2eee