### PR TITLE
Fix clippy uninlined-format-args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -743,7 +743,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             let script = std::fs::read_to_string(file)?;
             let result = feed_my_ledger::script::run_script(&script, &ledger)?;
-            println!("{}", result);
+            println!("{result}");
         }
         Commands::Switch { .. } | Commands::Login => unreachable!(),
     }


### PR DESCRIPTION
## Summary
- address clippy `uninlined_format_args` warning in `main.rs`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_6866c78295c4832ab2f427a25ece5174