### PR TITLE
fix: correct row orientation for Google Sheets bulk append

### DIFF
--- a/src/cloud_adapters/google_sheets4.rs
+++ b/src/cloud_adapters/google_sheets4.rs
@@ -236,7 +236,10 @@ impl CloudSpreadsheetService for GoogleSheets4Adapter {
                 .into_iter()
                 .map(|r| r.into_iter().map(serde_json::Value::String).collect())
                 .collect();
-            let body_json = json!({"values": rows_json});
+            let body_json = json!({
+                "majorDimension": "ROWS",
+                "values": rows_json,
+            });
             let req = Request::builder()
                 .method(Method::POST)
                 .uri(&url)

--- a/tests/cloud_adapter_tests.rs
+++ b/tests/cloud_adapter_tests.rs
@@ -116,7 +116,7 @@ async fn share_sheet_propagates_failure() {
 #[tokio::test]
 async fn append_rows_insert_option() {
     use serde_json::json;
-    use wiremock::matchers::{method, path, query_param};
+    use wiremock::matchers::{body_json, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
@@ -133,6 +133,10 @@ async fn append_rows_insert_option() {
         .and(path("/spreadsheets/sheet123/values/Ledger:append"))
         .and(query_param("valueInputOption", "USER_ENTERED"))
         .and(query_param("insertDataOption", "INSERT_ROWS"))
+        .and(body_json(json!({
+            "majorDimension": "ROWS",
+            "values": [["a"], ["b"]],
+        })))
         .respond_with(ResponseTemplate::new(200))
         .expect(1)
         .mount(&server)


### PR DESCRIPTION
## Summary
- set `majorDimension` to `ROWS` when appending values to Google Sheets to keep each new row starting at column A
- test that Google Sheets adapter sends `majorDimension: ROWS` with correct values

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_6890396166f8832aa32b287efb7525a5