### PR TITLE
Document currency flag for CSV imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ $ cargo run --bin ledger -- import --format csv --file transactions.csv \
 ```
 Mapping flags override the default column names when importing CSV files.
 
+If your CSV does not include a currency column, you can provide a default value:
+
+```bash
+$ cargo run --bin ledger -- import --format csv --file transactions.csv --currency USD
+```
+All imported rows will use the supplied currency.
+
 Ledger text and JSON formats can also be imported:
 
 ```bash


### PR DESCRIPTION
## Summary
- document how to supply a default currency when importing CSV data

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_689041e5570c832abf617e1c2b740804