### PR TITLE
Log tracing to stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -455,6 +455,7 @@ fn import_with_progress(
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(std::io::stdout)
         .init();
     info!("Starting feed-my-ledger");
     let rt = tokio::runtime::Runtime::new()?;


### PR DESCRIPTION
## Summary
- ensure tracing output goes to standard console

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68904cc708a4832a978fb59848a54ff4