### PR TITLE
Support currency override for all import formats

### DIFF
--- a/src/import/json.rs
+++ b/src/import/json.rs
@@ -40,6 +40,15 @@ pub fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
     JsonImporter::parse(path)
 }
 
+/// Parses a JSON file and sets all record currencies to the provided value.
+pub fn parse_with_currency(path: &Path, currency: &str) -> Result<Vec<Record>, ImportError> {
+    let mut records = JsonImporter::parse(path)?;
+    for rec in &mut records {
+        rec.currency = currency.to_string();
+    }
+    Ok(records)
+}
+
 pub fn parse_str(input: &str) -> Result<Vec<Record>, ImportError> {
     JsonImporter::parse_str(input)
 }

--- a/src/import/ledger.rs
+++ b/src/import/ledger.rs
@@ -99,6 +99,15 @@ pub fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
     LedgerImporter::parse(path)
 }
 
+/// Parses a ledger file and sets all record currencies to the provided value.
+pub fn parse_with_currency(path: &Path, currency: &str) -> Result<Vec<Record>, ImportError> {
+    let mut records = LedgerImporter::parse(path)?;
+    for rec in &mut records {
+        rec.currency = currency.to_string();
+    }
+    Ok(records)
+}
+
 pub fn parse_str(input: &str) -> Result<Vec<Record>, ImportError> {
     LedgerImporter::parse_str(input)
 }

--- a/src/import/ofx.rs
+++ b/src/import/ofx.rs
@@ -71,6 +71,15 @@ pub fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
     OfxImporter::parse(path)
 }
 
+/// Parses an OFX file and sets all record currencies to the provided value.
+pub fn parse_with_currency(path: &Path, currency: &str) -> Result<Vec<Record>, ImportError> {
+    let mut records = OfxImporter::parse(path)?;
+    for rec in &mut records {
+        rec.currency = currency.to_string();
+    }
+    Ok(records)
+}
+
 pub fn parse_str(input: &str) -> Result<Vec<Record>, ImportError> {
     OfxImporter::parse_str(input)
 }

--- a/src/import/qif.rs
+++ b/src/import/qif.rs
@@ -74,3 +74,12 @@ impl StatementImporter for QifImporter {
 pub fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
     QifImporter::parse(path)
 }
+
+/// Parses a QIF file and sets all record currencies to the provided value.
+pub fn parse_with_currency(path: &Path, currency: &str) -> Result<Vec<Record>, ImportError> {
+    let mut records = QifImporter::parse(path)?;
+    for rec in &mut records {
+        rec.currency = currency.to_string();
+    }
+    Ok(records)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -414,8 +414,7 @@ fn import_with_progress(
         })
         .ok_or_else(|| "could not determine file format".to_string())?;
     let mapping = mapping.into_mapping();
-    let currency_clone = currency.clone();
-    let mut records = match fmt.to_lowercase().as_str() {
+    let records = match fmt.to_lowercase().as_str() {
         "csv" => {
             if let Some(cur) = currency.as_deref() {
                 if let Some(ref map) = mapping {
@@ -429,18 +428,24 @@ fn import_with_progress(
                 import::csv::parse(file)
             }
         }
-        "qif" => import::qif::parse(file),
-        "ofx" => import::ofx::parse(file),
-        "ledger" => import::ledger::parse(file),
-        "json" => import::json::parse(file),
+        "qif" => match currency.as_deref() {
+            Some(cur) => import::qif::parse_with_currency(file, cur),
+            None => import::qif::parse(file),
+        },
+        "ofx" => match currency.as_deref() {
+            Some(cur) => import::ofx::parse_with_currency(file, cur),
+            None => import::ofx::parse(file),
+        },
+        "ledger" => match currency.as_deref() {
+            Some(cur) => import::ledger::parse_with_currency(file, cur),
+            None => import::ledger::parse(file),
+        },
+        "json" => match currency.as_deref() {
+            Some(cur) => import::json::parse_with_currency(file, cur),
+            None => import::json::parse(file),
+        },
         other => return Err(format!("unsupported format: {other}").into()),
     }?;
-
-    if let Some(cur) = currency_clone {
-        for rec in &mut records {
-            rec.currency = cur.clone();
-        }
-    }
 
     let pb = indicatif::ProgressBar::new(records.len() as u64);
     for rec in records {

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -90,6 +90,48 @@ fn csv_parsing_with_currency_override() {
 }
 
 #[test]
+fn qif_parsing_with_currency_override() {
+    let qif_content = "!Type:Bank\nD01/01/2024\nT-10.00\nPCoffee\nM\n^\n";
+    let path = write_temp("qif_override.qif", qif_content);
+    let records = qif::parse_with_currency(&path, "EUR").unwrap();
+    assert_eq!(records[0].currency, "EUR");
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn ofx_parsing_with_currency_override() {
+    let ofx_content = r#"<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><BANKTRANLIST>
+<STMTTRN><TRNAMT>-7.00</TRNAMT><NAME>Snack</NAME></STMTTRN>
+</BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>"#;
+    let path = write_temp("ofx_override.ofx", ofx_content);
+    let records = ofx::parse_with_currency(&path, "EUR").unwrap();
+    assert_eq!(records[0].currency, "EUR");
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn ledger_parsing_with_currency_override() {
+    let ledger_text = "2024-01-01 Coffee\n    expenses:food  5.00 USD\n    cash\n";
+    let path = write_temp("ledger_override.ledger", ledger_text);
+    let records = ledger::parse_with_currency(&path, "EUR").unwrap();
+    assert_eq!(records[0].currency, "EUR");
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn json_parsing_with_currency_override() {
+    let ledger_text = "2024-01-01 Coffee\n    expenses:food  5.00 USD\n    cash\n";
+    let lpath = write_temp("json_from_ledger.ledger", ledger_text);
+    let records = ledger::parse(&lpath).unwrap();
+    let jpath = write_temp("json_override.json", "");
+    json::export(&jpath, &records).unwrap();
+    let loaded = json::parse_with_currency(&jpath, "EUR").unwrap();
+    assert_eq!(loaded[0].currency, "EUR");
+    let _ = std::fs::remove_file(lpath);
+    let _ = std::fs::remove_file(jpath);
+}
+
+#[test]
 fn ledger_and_json_roundtrip() {
     let ledger_text = "2024-01-01 Coffee\n    expenses:food  5.00 USD\n    cash\n";
     let lpath = write_temp("test.ledger", ledger_text);


### PR DESCRIPTION
## Summary
- add `parse_with_currency` helpers for ledger, JSON, QIF and OFX importers
- route CLI imports through new helpers to respect `--currency` for every format
- test currency override across all import formats

## Testing
- `cargo clippy --all-targets --all-features -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_689055ebd230832a81dd7dbb6e59bc82