### PR TITLE
Remove duplicate currency helpers

### DIFF
--- a/src/import/ofx.rs
+++ b/src/import/ofx.rs
@@ -96,15 +96,6 @@ pub fn parse_with_date_format(path: &Path, fmt: &str) -> Result<Vec<Record>, Imp
     OfxImporter::parse_internal(path, Some(fmt))
 }
 
-/// Parses an OFX file and sets all record currencies to the provided value.
-pub fn parse_with_currency(path: &Path, currency: &str) -> Result<Vec<Record>, ImportError> {
-    let mut records = OfxImporter::parse(path)?;
-    for rec in &mut records {
-        rec.currency = currency.to_string();
-    }
-    Ok(records)
-}
-
 pub fn parse_str(input: &str) -> Result<Vec<Record>, ImportError> {
     OfxImporter::parse_str(input, None)
 }

--- a/src/import/qif.rs
+++ b/src/import/qif.rs
@@ -106,15 +106,6 @@ pub fn parse_with_date_format(path: &Path, fmt: &str) -> Result<Vec<Record>, Imp
     QifImporter::parse_internal(path, Some(fmt))
 }
 
-/// Parses a QIF file and sets all record currencies to the provided value.
-pub fn parse_with_currency(path: &Path, currency: &str) -> Result<Vec<Record>, ImportError> {
-    let mut records = QifImporter::parse(path)?;
-    for rec in &mut records {
-        rec.currency = currency.to_string();
-    }
-    Ok(records)
-}
-
 pub fn parse_str(input: &str) -> Result<Vec<Record>, ImportError> {
     QifImporter::parse_str(input, None)
 }


### PR DESCRIPTION
## Summary
- remove duplicate `parse_with_currency` definitions

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_689080f88208832a92913dc49a6aee48