### PR TITLE
Allow configuring batch size via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ $ cargo run --bin feed-my-ledger -- --local-dir ledger_data add \
 $ cargo run --bin feed-my-ledger -- --local-dir ledger_data list
 ```
 
+Adjust how many rows are sent per request with `--batch-size` (default `100`):
+
+```bash
+$ cargo run --bin feed-my-ledger -- --batch-size 50 add \
+    --description "Coffee" \
+    --debit cash --credit expenses \
+    --amount 3.5 --currency USD
+```
+
 Before issuing API commands for the first time, authorize the application:
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,6 +123,15 @@ $ cargo run --bin ledger -- --local-dir ledger_data add \
 $ cargo run --bin ledger -- --local-dir ledger_data list
 ```
 
+Control how many rows are sent per request with `--batch-size` (default `100`):
+
+```bash
+$ cargo run --bin ledger -- --batch-size 50 add \
+    --description "Coffee" \
+    --debit cash --credit expenses \
+    --amount 3.5 --currency USD
+```
+
 Split transactions use the same command with an additional `--splits` argument
 containing a JSON array of extra postings:
 


### PR DESCRIPTION
## Summary
- make row batch size configurable with `--batch-size` using `BATCH_SIZE` as default
- document batch size option in README and docs

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_6890f94aa50c832a9998aa2310b90775